### PR TITLE
Add optional symlink and subdirectory support, and prevent locale warnings

### DIFF
--- a/transcode.sh
+++ b/transcode.sh
@@ -140,7 +140,6 @@ fi
 find_command="$find_command -type f -name \"*.mkv\""
 
 #run constructed find command
-echo $find_command
 eval "$find_command" | LC_ALL=C parallel -j "$parallel_processes" transcode_file
 
 


### PR DESCRIPTION
this commit reworks the find command to be more dynamic and adds options to include subdirectories and symlinks as well as use LC_ALL=C to prevent some locale warnings